### PR TITLE
rename config file default

### DIFF
--- a/anaconda_ident/install.py
+++ b/anaconda_ident/install.py
@@ -351,7 +351,7 @@ def main():
         msg = "-" * len(msg)
         print(msg)
         if len(sys.argv) <= 1:
-            sys.argv[0] = "conda-ident"
+            sys.argv[0] = "anaconda-ident"
             p.print_help()
             print(msg)
     manage_patch(args)

--- a/anaconda_ident/keymgr.py
+++ b/anaconda_ident/keymgr.py
@@ -48,8 +48,8 @@ def parse_argv():
     )
     p.add_argument(
         "--name",
-        default="conda-ident-config",
-        help="The conda name for the package. Defaults to conda-ident-config.",
+        default="anaconda-ident-config",
+        help="The conda name for the package. Defaults to anaconda-ident-config.",
     )
     p.add_argument(
         "--version",


### PR DESCRIPTION
Fixes #43
Change the default name of the config file to `anaconda-ident-config`