### PR TITLE
Fix entrypoints on windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,19 @@ jobs:
         source $CONDA/etc/profile.d/conda.sh
         conda install anaconda-client constructor conda-index local::anaconda-ident
         conda create -p ./testenv local::anaconda-ident conda==${{ matrix.cversion }}
+    - name: Test endpoints (Windows)
+      if: matrix.os == 'windows-latest'
+      shell: cmd
+      run: |
+        call %CONDA%/Scripts/activate
+        anaconda-ident --status
+        anaconda-keymgr --help
+    - name: Test endpoints (Unix)
+      if: matrix.os != 'windows-latest'
+      run: |
+        source $CONDA/bin/activate
+        anaconda-ident --status
+        anaconda-keymgr --help
     - name: Build an installer
       env:
         TEST_REPO_TOKEN: ${{ secrets.ANACONDA_TOKEN }}

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
 
 build:
   noarch: python
-  entrypoints:
+  entry_points:
     - anaconda-ident = anaconda_ident.install:main
     - anaconda-keymgr = anaconda_ident.keymgr:main
 


### PR DESCRIPTION
Fixes #53.

The noarch package works on Windows in all respects _except_ for the lack of `anaconda-keymgr` and `anaconda-ident` executables.