### PR TITLE
use import hooks to reduce circular imports

### DIFF
--- a/anaconda_ident/install.py
+++ b/anaconda_ident/install.py
@@ -141,20 +141,15 @@ except Exception as exc:
 """
 
 PATCH_TEXT = b"""
-# anaconda_ident p2
-_old__init__ = context.__init__
-def _new_init(*args, **kwargs):
-    try:
-        import anaconda_ident.patch
-    except Exception as exc:
-        import os, sys
-        print("Error loading anaconda_ident:", exc, file=sys.stderr)
-        if os.environ.get('ANACONDA_IDENT_DEBUG'):
-            raise
-    context.__init__ = _old__init__
-    _old__init__(*args, **kwargs)
-context.__init__ = _new_init
-# anaconda_ident p2
+# anaconda_ident p3
+try:
+    import anaconda_ident.patch
+except Exception as exc:
+    import os, sys
+    print("Error loading anaconda_ident:", exc, file=sys.stderr)
+    if os.environ.get('ANACONDA_IDENT_DEBUG'):
+        raise
+# anaconda_ident p3
 """
 
 AC_PATCH_TEXT = b"""

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
   run:
     - python>=3.6
     - conda>=22.11.0
+    - wrapt
 
 test:
   commands:


### PR DESCRIPTION
Now that we're patching multiple files I studied to see if we could reduce circular imports further. The `register_post_import_hook` approach, first offered in [PEP 0369](https://peps.python.org/pep-0369/) and now offered in the [wrapt module](https://wrapt.readthedocs.io/en/latest/index.html), provides a cleaner way to go. This allows the patch module to completely avoid importing likely circular import candidates. Instead, it is only importing the module it is patching and a utility module that is known not to introduce cycles. The `conda.cli.install` and `conda.gateways.connection.session` patches are delayed.

I'm not sure if this is worth doing. Is the additional dependency a real benefit? Doesn't seem so