### PR TITLE
break out patch code into separate modules

### DIFF
--- a/anaconda_ident/install.py
+++ b/anaconda_ident/install.py
@@ -147,7 +147,8 @@ def _new_init(*args, **kwargs):
     try:
         import anaconda_ident.patch
     except Exception as exc:
-        print("Error loading anaconda_ident:", exc)
+        import os, sys
+        print("Error loading anaconda_ident:", exc, file=sys.stderr)
         if os.environ.get('ANACONDA_IDENT_DEBUG'):
             raise
     context.__init__ = _old__init__
@@ -159,14 +160,10 @@ context.__init__ = _new_init
 AC_PATCH_TEXT = b"""
 # anaconda_ident p3
 try:
-    from anaconda_ident.tokens import include_baked_tokens
-    _old_read_binstar_tokens = read_binstar_tokens
-    def read_binstar_tokens():
-        tokens = _old_read_binstar_tokens()
-        include_baked_tokens(tokens)
-        return tokens
+    import anaconda_ident.patch_ac
 except Exception as exc:
-    print("Error loading anaconda_ident:", exc)
+    import os, sys
+    print("Error loading anaconda_ident:", exc, file=sys.stderr)
     if os.environ.get('ANACONDA_IDENT_DEBUG'):
         raise
 # anaconda_ident p3
@@ -175,12 +172,10 @@ except Exception as exc:
 BS_PATCH_TEXT = b"""
 # anaconda_ident p3
 try:
-    from anaconda_ident.tokens import load_baked_token
-    _old_load_token = load_token
-    def load_token(url):
-        return _old_load_token(url) or load_baked_token(url)
+    import anaconda_ident.patch_bc
 except Exception as exc:
-    print("Error loading anaconda_ident:", exc)
+    import os, sys
+    print("Error loading anaconda_ident:", exc, file=sys.stderr)
     if os.environ.get('ANACONDA_IDENT_DEBUG'):
         raise
 # anaconda_ident p3

--- a/anaconda_ident/patch_ac.py
+++ b/anaconda_ident/patch_ac.py
@@ -1,0 +1,13 @@
+from conda.gateways import anaconda_client as ac
+from anaconda_ident.tokens import include_baked_tokens
+
+
+def _new_read_binstar_tokens():
+    tokens = ac._old_read_binstar_tokens()
+    include_baked_tokens(tokens)
+    return tokens
+
+
+if not hasattr(ac, "_old_read_binstar_tokens"):
+    ac._old_read_binstar_tokens = ac.read_binstar_tokens
+    ac.read_binstar_tokens = _new_read_binstar_tokens

--- a/anaconda_ident/patch_bc.py
+++ b/anaconda_ident/patch_bc.py
@@ -1,0 +1,11 @@
+from binstar_client.utils import config as bc
+from anaconda_ident.tokens import load_baked_token
+
+
+def _new_load_token(url):
+    return bc._old_load_token(url) or load_baked_token(url)
+
+
+if not hasattr(bc, "_old_load_token"):
+    bc._old_load_token = bc.load_token
+    bc.load_token = _new_load_token

--- a/anaconda_ident/tokens.py
+++ b/anaconda_ident/tokens.py
@@ -7,7 +7,7 @@ def get_baked_tokens():
         try:
             from conda.base.context import context
 
-            if not hasattr(context, "repo_tokens"):
+            if not getattr(context, "repo_tokens", None):
                 context.__init__()
             _baked_tokens = context.repo_tokens
         except Exception:

--- a/tests/test_environment.sh
+++ b/tests/test_environment.sh
@@ -84,7 +84,7 @@ fi
 
 echo -n "token in conda ..."
 url=https://repo.anaconda.cloud/repo/main/linux-64/repodata.json
-conda_token=$($T_PYTHON -c 'from conda.gateways.connection.session import CondaHttpAuth;print(CondaHttpAuth.add_binstar_token("'$url'"))')
+conda_token=$($T_PYTHON -c 'import conda.base.context;from conda.gateways.connection.session import CondaHttpAuth;print(CondaHttpAuth.add_binstar_token("'$url'"))')
 if echo "$conda_token" | grep -q "/t/$repo_token/"; then
   echo "yes"
 else


### PR DESCRIPTION
- Break the actual module modifications for binstar and anaconda-client into separate modules, just like the main patch
- Add `import os, sys` to the error reporting to make sure they're available regardless of changes to the parent module