### PR TITLE
improve detection of unloaded context

### DIFF
--- a/anaconda_ident/tokens.py
+++ b/anaconda_ident/tokens.py
@@ -7,7 +7,11 @@ def get_baked_tokens():
         try:
             from conda.base.context import context
 
-            if not getattr(context, "repo_tokens", None):
+            # When importing the context module outside of
+            # conda, the context object will not be initialized.
+            # We detect this by looking for our patched value
+            # of repo_tokens. If it is not there, initialize
+            if not hasattr(context, "repo_tokens"):
                 context.__init__()
             _baked_tokens = context.repo_tokens
         except Exception:


### PR DESCRIPTION
Justin discovered a weird circumstance where `--yes` would sometimes not be respected. It turns out that the cause was that the `get_baked_tokens` function below was being too aggressive about ensuring that the configuration context was loaded into memory.

The reason it has to check that in the first place is that `conda-token` imports `conda.gateways.anaconda_client` directly. In that circumstance, when the patched version of that module calls `get_baked_tokens`, it will find that the configuration has not been loaded yet.

But I wasn't using good logic to detect whether that was so. I was simply testing to see if the `repo_tokens` dictionary was empty or None. That's not a good test, of course, in a case where this value is deliberately empty. To fix, we will just check to see if the patching has occurred. An easy way to do that is to see if `repo_tokens` is not present.

So the end result was that a reload attempt was being triggered at a time it was not expected, and that was clearing out the command-line flags. This was happening at such a late stage of the conda command that most of time time, it wasn't deleterious. Justin found a case where it was.

Fortunately, our pro customers have a non-empty repo_tokens value, so they will not be affected.