### PR TITLE
Extend + apply pre-commit, add pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,28 @@
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+
+name: pre-commit
+
+concurrency:
+  # Concurrency group that uses the workflow name and PR number if available
+  # or commit SHA as a fallback. If a new build is triggered under that
+  # concurrency group while a previous build is running it will be canceled.
+  # Repeated pushes to a PR will cancel all previous builds, while multiple
+  # merges to main will not cancel.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+      - uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4
+        with:
+          python-version: '3.8'
+      - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 # v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@
 #   Check out the docs at: https://pre-commit.com/
 
 default_stages: [commit]
+exclude: versioneer.py|anaconda_ident/_version.py
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
@@ -11,11 +12,19 @@ repos:
       - id: check-builtin-literals
       - id: check-case-conflict
       - id: check-docstring-first
-      - id: check-executables-have-shebangs
-      - id: check-toml
+      # - id: check-executables-have-shebangs
       - id: detect-private-key
       - id: trailing-whitespace
       - id: end-of-file-fixer
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.10.1
+    hooks:
+      - id: pyupgrade
+        args: [--py36-plus]
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:
@@ -24,3 +33,17 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.5
+    hooks:
+      - id: codespell
+        args: [--write]
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.24.1
+    hooks:
+      - id: check-github-workflows
+      - id: check-renovate
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ the telemetry insertion.
 The easiest way to verify that it is
 engaged is by typing `conda info` and examining the `user-agent`
 line. The user-agent string will look something like this
-(split over two lines for readibility):
+(split over two lines for readability):
 
 ```
 conda/22.11.1 requests/2.28.1 CPython/3.10.4 Darwin/22.2.0
@@ -159,13 +159,13 @@ All of the tokens produced by `anaconda-ident` take the form
 
 A standard configuration string is simply a combination of one
 or more of the characters `c`, `s`, `e`, `u`, `h`, and `n`. To
-include an organization string, append it to this configuraton
+include an organization string, append it to this configuration
 with a leading colon `:`.
 
 Here are some examples:
 
 - `cse`: the default combination of client, session and environment.
-- `uh:finance`: username, hostname, and a `finance` organziation.
+- `uh:finance`: username, hostname, and a `finance` organization.
 - `cseuhn:eng`: all the tokens, including an `eng` organization.
 
 For convenience, a number of special keywords are also available,
@@ -245,7 +245,7 @@ it according to the settings provided.
 If you are an Anaconda customer interested in deploying
 `anaconda-ident` within your organization, please feel free to
 reach out to [Anaconda Support](mailto:support@anaconda.com).
-We can offer the folllowing custom buidls:
+We can offer the following custom builds:
 
 - A set of `anaconda-ident` packages containing your
   preferred configuration.

--- a/anaconda_ident/install.py
+++ b/anaconda_ident/install.py
@@ -1,9 +1,8 @@
-import sysconfig
 import argparse
+import os
 import stat
 import sys
-import os
-
+import sysconfig
 from os.path import basename, dirname, exists, join, relpath
 from traceback import format_exc
 
@@ -63,7 +62,7 @@ def configure_parser(p):
         "--channel-alias",
         default=None,
         help="Specify a channel_alias. "
-        "This is recomended only if all channels are sourced from the same repository; "
+        "This is recommended only if all channels are sourced from the same repository; "
         "e.g., an instance of Anaconda Server. Supply an empty string to clear the "
         "channel alias setting.",
     )
@@ -320,8 +319,8 @@ def _patch_conda_context(args, verbose):
 
 def _patch_anaconda_client(args, verbose):
     global AC_PATCH_TEXT
-    afile = join(_sp_dir(), "conda", "gateways", "anaconda_client.py")
-    _patch(args, afile, AC_PATCH_TEXT, None, 2000)
+    acfile = join(_sp_dir(), "conda", "gateways", "anaconda_client.py")
+    _patch(args, acfile, AC_PATCH_TEXT, None, 2000)
 
 
 def _patch_binstar_client(args, verbose):
@@ -362,7 +361,7 @@ def _yaml():
 def _print_config(what, args, config):
     if args.verbose or args.status:
         value = config.get("anaconda_ident")
-        print("%s user agent: %s" % (what, value or "<default>"))
+        print("{} user agent: {}".format(what, value or "<default>"))
 
 
 def _print_default_channels(what, args, config):
@@ -374,13 +373,13 @@ def _print_default_channels(what, args, config):
             value = "[]"
         else:
             value = "\n - " + "\n - ".join(value)
-        print("%s default_channels: %s" % (what, value))
+        print(f"{what} default_channels: {value}")
 
 
 def _print_channel_alias(what, args, config):
     if args.verbose or args.status:
         value = config.get("channel_alias")
-        print("%s channel_alias: %s" % (what, value or "<none>"))
+        print("{} channel_alias: {}".format(what, value or "<none>"))
 
 
 def _print_tokens(what, args, config):
@@ -389,7 +388,7 @@ def _print_tokens(what, args, config):
         if tokens:
             print("%s repo tokens:" % what)
             for k, v in tokens.items():
-                print(" - %s: %s..." % (k, v[:6]))
+                print(f" - {k}: {v[:6]}...")
         else:
             print("%s repo tokens: <none>" % what)
 
@@ -406,11 +405,11 @@ def read_condarc(args, fname):
     fexists = exists(fname)
     if verbose:
         spath = relpath(fname, sys.prefix)
-        print("config file: %s%s" % (spath, "" if fexists else " (not present)"))
+        print("config file: {}{}".format(spath, "" if fexists else " (not present)"))
     if not fexists:
         return {}
     try:
-        with open(fname, "r") as fp:
+        with open(fname) as fp:
             condarc = _yaml().safe_load(fp)
     except Exception:
         error("config load failed")

--- a/anaconda_ident/keymgr.py
+++ b/anaconda_ident/keymgr.py
@@ -1,13 +1,13 @@
-import hashlib
 import argparse
-import sys
+import hashlib
+import io
 import json
 import os
-import io
-
-from tarfile import open as tf_open, TarInfo
+import sys
 from datetime import datetime
 from os.path import basename, dirname
+from tarfile import TarInfo
+from tarfile import open as tf_open
 
 try:
     import ruamel.yaml as ruamel_yaml
@@ -36,7 +36,7 @@ def parse_argv():
         "--channel-alias",
         default=None,
         help="Specify a channel_alias. "
-        "This is recomended only if all channels are sourced from the same repository; "
+        "This is recommended only if all channels are sourced from the same repository; "
         "e.g., an instance of Anaconda Server.",
     )
     p.add_argument(
@@ -161,11 +161,11 @@ def build_tarfile(dname, args, config_dict):
     h = hashlib.new("sha256")
     h.update(config_data)
     config_hash = h.hexdigest()
-    fname = "%s-%s-%s.tar.bz2" % (name, version, build_string)
+    fname = f"{name}-{version}-{build_string}.tar.bz2"
     fpath = os.path.join(dname or ".", fname)
     verbose = args.verbose or args.dry_run
     if verbose:
-        msg = "Building %s%s" % (fname, " (dry_run)" if args.dry_run else "")
+        msg = "Building {}{}".format(fname, " (dry_run)" if args.dry_run else "")
         print(msg)
         print(LINE)
 
@@ -236,7 +236,7 @@ def build_config_dict(args):
         if verbose:
             print("repo_tokens:")
             for k, v in result["repo_tokens"].items():
-                print("  %s: %s" % (k, v))
+                print(f"  {k}: {v}")
     return result
 
 

--- a/anaconda_ident/patch.py
+++ b/anaconda_ident/patch.py
@@ -1,28 +1,26 @@
 import base64
 import getpass
+import hashlib
 import os
 import platform
 import sys
-import hashlib
+from logging import getLogger
+from os.path import basename, exists, expanduser, join
 
 import conda.base.context as c_context
+from conda.auxlib.decorators import memoize, memoizedproperty
 from conda.base.context import (
     Context,
-    context,
-    env_name,
+    MapParameter,
     ParameterLoader,
     PrimitiveParameter,
-    MapParameter,
+    context,
+    env_name,
 )
-from conda.gateways.connection.session import CondaHttpAuth
-from conda.auxlib.decorators import memoize, memoizedproperty
 from conda.cli import install as cli_install
-
-from logging import getLogger
-from os.path import join, basename, expanduser, exists
+from conda.gateways.connection.session import CondaHttpAuth
 
 from . import __version__
-
 
 log = getLogger(__name__)
 

--- a/anaconda_ident/patch_ac.py
+++ b/anaconda_ident/patch_ac.py
@@ -1,4 +1,5 @@
 from conda.gateways import anaconda_client as ac
+
 from anaconda_ident.tokens import include_baked_tokens
 
 

--- a/anaconda_ident/patch_bc.py
+++ b/anaconda_ident/patch_bc.py
@@ -1,4 +1,5 @@
 from binstar_client.utils import config as bc
+
 from anaconda_ident.tokens import load_baked_token
 
 

--- a/anaconda_ident/plugin.py
+++ b/anaconda_ident/plugin.py
@@ -1,4 +1,5 @@
-from conda import plugins, __version__ as conda_version
+from conda import __version__ as conda_version
+from conda import plugins
 
 from . import install
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,8 @@
+[isort]
+profile=black
+
 [flake8]
 max-line-length = 100
-ignore = E122,E123,E126,E127,E128,E731,E722,E203,W503
 exclude = build,anaconda_ident/_version.py,tests,conda.recipe,.git,versioneer.py,benchmarks,.asv
 
 [tool:pytest]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup
+
 import versioneer
 
 setup(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,10 @@
 import os
-import sys
 import subprocess
+import sys
 
-from anaconda_ident import patch, __version__
 from conda.base.context import context
+
+from anaconda_ident import __version__, patch
 
 context.__init__()
 


### PR DESCRIPTION
Adds pyupgrade + isort + codespell + check-jsonschema + meta hooks and fully applies them.

isort sorts the imports according to https://peps.python.org/pep-0008/#imports to bring them in alphabetical order and  to prevent stdlib/third party name space overwrites by ordering them into the sections:

1. Standard library imports.
2. Related third party imports.
3. Local application/library specific imports.

pyupgrade mainly converts the string formatting to f-strings where possible.

codespell fixes a bunch of typos.

The meta hooks find not applied hooks that then get disabled.

All the flake8 ignores are removed from t he setup.cfg as they are not needed.

A pre-commit workflow helps to review PRs.

The PR is 100% automatically generated by pre-commit, except the afile for acfile var rename to prevent a codespell false positive.