### PR TITLE
Fix URL in conda recipe

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -29,7 +29,7 @@ test:
     - anaconda-keymgr --help
 
 about:
-  home: https://github.com/mcg1969/anaconda-ident
+  home: https://github.com/Anaconda-Platform/anaconda-ident
   summary: simple, opt-in user identification for conda clients
   license: {{ data.get('license') }}
   license_file: LICENSE


### PR DESCRIPTION
This is a follow up to https://github.com/Anaconda-Platform/anaconda-ident/pull/73 and updates the URL is the recipe that is in the end shown here https://anaconda.org/mcg/anaconda-ident