### PR TITLE
Configure concurrency in the main workflow for faster responses

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,16 @@ on:
   pull_request:
     branches:
       - main
+
+concurrency:
+  # Concurrency group that uses the workflow name and PR number if available
+  # or commit SHA as a fallback. If a new build is triggered under that
+  # concurrency group while a previous build is running it will be canceled.
+  # Repeated pushes to a PR will cancel all previous builds, while multiple
+  # merges to main will not cancel.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Inspired by https://github.com/conda/conda/blob/main/.github/workflows/tests.yml#L21

It not only saves resources, but also leads to faster CI responses, if multiple changes are done to a PR when CI already started.