### PR TITLE
Add shellcheck to pre-commit and fix findings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,8 @@ repos:
       - id: check-builtin-literals
       - id: check-case-conflict
       - id: check-docstring-first
-      # - id: check-executables-have-shebangs
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
       - id: detect-private-key
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -33,6 +34,10 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.9.0.2
+    hooks:
+      - id: shellcheck
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.5
     hooks:

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 "${PREFIX}/bin/python" -m pip install --no-deps --ignore-installed -vv .
 mkdir -p "${PREFIX}/etc/conda/activate.d"
 mkdir -p "${PREFIX}/python-scripts"

--- a/conda.recipe/post-link.sh
+++ b/conda.recipe/post-link.sh
@@ -1,4 +1,6 @@
+#!/bin/sh
+
 pfx=${CONDA_PREFIX:-${PREFIX:-}}
-pbin=${pfx}/python.exe
-[ -f ${pbin} ] || pbin=${pfx}/bin/python
-${pbin} -m anaconda_ident.install --verify --quiet >>"${pfx}/.messages.txt" 2>&1
+pbin="${pfx}/python.exe"
+[ -f "${pbin}" ] || pbin="${pfx}/bin/python"
+"${pbin}" -m anaconda_ident.install --verify --quiet >>"${pfx}/.messages.txt" 2>&1

--- a/conda.recipe/pre-unlink.sh
+++ b/conda.recipe/pre-unlink.sh
@@ -1,4 +1,6 @@
+#!/bin/sh
+
 pfx=${CONDA_PREFIX:-${PREFIX:-}}
-pbin=${pfx}/python.exe
-[ -f ${pbin} ] || pbin=${pfx}/bin/python
-${pbin} -m anaconda_ident.install --disable --quiet >>"${pfx}/.messages.txt" 2>&1
+pbin="${pfx}/python.exe"
+[ -f "${pbin}" ] || pbin="${pfx}/bin/python"
+"${pbin}" -m anaconda_ident.install --disable --quiet >>"${pfx}/.messages.txt" 2>&1

--- a/tests/test_environment.sh
+++ b/tests/test_environment.sh
@@ -1,31 +1,31 @@
 #!/bin/bash
 
-set -e
+set -o errtrace -o nounset -o pipefail -o errexit
 
 echo "Environment tester"
 echo "------------------------"
-T_PREFIX=$(cd $1 && pwd); shift
+T_PREFIX=$(cd "$1" && pwd); shift
 echo "prefix ... $T_PREFIX"
 
 echo -n "python ... "
 T_PYTHON_WIN=$T_PREFIX/python.exe
 T_PYTHON_UNX=$T_PREFIX/bin/python
-if [ -x $T_PYTHON_WIN ]; then
+if [ -x "$T_PYTHON_WIN" ]; then
   T_PYTHON=$T_PYTHON_WIN
-elif [ -x $T_PYTHON_UNX ]; then
+elif [ -x "$T_PYTHON_UNX" ]; then
   T_PYTHON=$T_PYTHON_UNX
 fi
 if [ -z "$T_PYTHON" ]; then
   echo "MISSING"
-  exit -1
+  exit 1
 fi
-echo $T_PYTHON
+echo "$T_PYTHON"
 
 echo -n "token ... "
 repo_token=$1; shift
 if [ -z "$repo_token" ]; then
   echo "MISSING"
-  exit -1
+  exit 1
 fi
 echo "${repo_token:0:6}..."
 success=yes
@@ -57,7 +57,7 @@ echo
 echo -n "correct prefix ... "
 test_prefix=$(echo "$status" | sed -nE 's@ *conda prefix: @@p')
 # For windows this converts the prefix to posix
-test_prefix=$(cd $test_prefix && pwd)
+test_prefix=$(cd "$test_prefix" && pwd)
 if [ "$test_prefix" = "$T_PREFIX" ]; then
   echo "yes"
 else
@@ -66,8 +66,8 @@ else
 fi
 
 echo -n "enabled ... "
-cnt=$(echo "$status" | grep "^. status: ENABLED" | wc -l)
-if [ $cnt == 3 ]; then
+cnt=$(echo "$status" | grep -c "^. status: ENABLED")
+if [ "$cnt" == 3 ]; then
   echo "yes"
 else
   echo "NO"
@@ -129,5 +129,5 @@ if [ "$success" = yes ]; then
   exit 0
 else
   echo "one or more errors detected"
-  exit -1
+  exit 1
 fi

--- a/tests/test_keymgr.sh
+++ b/tests/test_keymgr.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-set -e
+set -o errtrace -o nounset -o pipefail -o errexit
 
-SCRIPTDIR=$(cd $(dirname $BASH_SOURCE[0]) && pwd)
-source $CONDA_PREFIX/etc/profile.d/conda.sh
+SCRIPTDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck disable=SC1091
+source "$CONDA_PREFIX/etc/profile.d/conda.sh"
 
 bnum=0
 ver=$(date +%Y%m%d)
-grep '|' $SCRIPTDIR/config_tests.txt | while IFS="|" read cstr def cha rtk bstr; do
+grep '|' "$SCRIPTDIR"/config_tests.txt | while IFS="|" read -r cstr def cha rtk bstr; do
     bnum=$((bnum + 1))
     echo "--------"
     echo "config string: $cstr"
@@ -23,14 +24,14 @@ grep '|' $SCRIPTDIR/config_tests.txt | while IFS="|" read cstr def cha rtk bstr;
     echo "$output"
     echo "--------"
     fname=$(echo "$output" | tail -1)
-    [ -f "$fname" ] || exit -1
-    rm -rf $CONDA_PREFIX/pkgs/${fname%%.*}
-    conda install -p $CONDA_PREFIX $fname --freeze-installed --offline --yes
+    [ -f "$fname" ] || exit 1
+    rm -rf "$CONDA_PREFIX"/pkgs/"${fname%%.*}"
+    conda install -p "$CONDA_PREFIX" "$fname" --freeze-installed --offline --yes
     echo "--------"
-    conda list testpkg | grep -q ^testpkg || exit -1
+    conda list testpkg | grep -q ^testpkg || exit 1
     CONFIG_STRING="$cstr" DEFAULT_CHANNELS="$def" \
         CHANNEL_ALIAS="$cha" REPO_TOKEN="$rtk" \
-        ANACONDA_IDENT_DEBUG=1 SKIP_INSTALL=1 python $SCRIPTDIR/test_config.py
-    conda remove -p $CONDA_PREFIX testpkg --force --offline --yes
-    rm $fname
+        ANACONDA_IDENT_DEBUG=1 SKIP_INSTALL=1 python "$SCRIPTDIR"/test_config.py
+    conda remove -p "$CONDA_PREFIX" testpkg --force --offline --yes
+    rm "$fname"
 done


### PR DESCRIPTION
Also setting shebangs in build.sh, pre-/post-link.sh files, so that shellcheck knows the shell standard to check.

The added variable quoting (as requested by the linter) should also fixe real issues with spaces in conda_prefix dir.

The ./test/test_*.sh scripts contained some code that was invalid, like `exit -1` or the `-f AIDTest*.sh` etc.

Shellscript syntax can behave completely unexpected, shellcheck really helps to make scripts reliable.

Full list of what is addressed here:

```
In conda.recipe/build.sh line 1:
"${PREFIX}/bin/python" -m pip install --no-deps --ignore-installed -vv .
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In conda.recipe/post-link.sh line 1:
pfx=${CONDA_PREFIX:-${PREFIX:-}}
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In conda.recipe/post-link.sh line 3:
[ -f ${pbin} ] || pbin=${pfx}/bin/python
     ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
[ -f "${pbin}" ] || pbin=${pfx}/bin/python


In conda.recipe/pre-unlink.sh line 1:
pfx=${CONDA_PREFIX:-${PREFIX:-}}
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.


In conda.recipe/pre-unlink.sh line 3:
[ -f ${pbin} ] || pbin=${pfx}/bin/python
     ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
[ -f "${pbin}" ] || pbin=${pfx}/bin/python


In tests/test_environment.sh line 7:
T_PREFIX=$(cd $1 && pwd); shift
              ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
T_PREFIX=$(cd "$1" && pwd); shift


In tests/test_environment.sh line 13:
if [ -x $T_PYTHON_WIN ]; then
        ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
if [ -x "$T_PYTHON_WIN" ]; then


In tests/test_environment.sh line 15:
elif [ -x $T_PYTHON_UNX ]; then
          ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
elif [ -x "$T_PYTHON_UNX" ]; then


In tests/test_environment.sh line 20:
  exit -1
       ^-- SC2242 (error): Can only exit with status 0-255. Other data should be written to stdout/stderr.


In tests/test_environment.sh line 22:
echo $T_PYTHON
     ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
echo "$T_PYTHON"


In tests/test_environment.sh line 28:
  exit -1
       ^-- SC2242 (error): Can only exit with status 0-255. Other data should be written to stdout/stderr.


In tests/test_environment.sh line 60:
test_prefix=$(cd $test_prefix && pwd)
                 ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
test_prefix=$(cd "$test_prefix" && pwd)


In tests/test_environment.sh line 69:
cnt=$(echo "$status" | grep "^. status: ENABLED" | wc -l)
                       ^-----------------------^ SC2126 (style): Consider using 'grep -c' instead of 'grep|wc -l'.


In tests/test_environment.sh line 70:
if [ $cnt == 3 ]; then
     ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
if [ "$cnt" == 3 ]; then


In tests/test_environment.sh line 132:
  exit -1
       ^-- SC2242 (error): Can only exit with status 0-255. Other data should be written to stdout/stderr.


In tests/test_installer.sh line 6:
if [ ! -z $1 ]; then vflag="==$1"; shift; fi
     ^-- SC2236 (style): Use -n instead of ! -z.
          ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
if [ ! -z "$1" ]; then vflag="==$1"; shift; fi


In tests/test_installer.sh line 8:
SCRIPTDIR=$(cd $(dirname $BASH_SOURCE[0]) && pwd)
^-------^ SC2034 (warning): SCRIPTDIR appears unused. Verify use (or export if used externally).
               ^------------------------^ SC2046 (warning): Quote this to prevent word splitting.
                         ^-- SC1087 (error): Use braces when expanding arrays, e.g. ${array[idx]} (or ${var}[.. to quiet).
                         ^----------^ SC2128 (warning): Expanding an array without an index only gives the first element.
                         ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
SCRIPTDIR=$(cd $(dirname "$BASH_SOURCE"[0]) && pwd)


In tests/test_installer.sh line 9:
CONDA_PREFIX=$(cd $CONDA_PREFIX && pwd)
                  ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
CONDA_PREFIX=$(cd "$CONDA_PREFIX" && pwd)


In tests/test_installer.sh line 10:
source $CONDA_PREFIX/*/activate
       ^----------------------^ SC1090 (warning): ShellCheck can't follow non-constant source. Use a directive to specify location.
       ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
source "$CONDA_PREFIX"/*/activate


In tests/test_installer.sh line 12:
CONDA_PREFIX=$(cd $CONDA_PREFIX && pwd)
                  ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
CONDA_PREFIX=$(cd "$CONDA_PREFIX" && pwd)


In tests/test_installer.sh line 17:
    --repo-token $repo_token --config-string full:installertest \
                 ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    --repo-token "$repo_token" --config-string full:installertest \


In tests/test_installer.sh line 19:
mkdir -p $CONDA_PREFIX/conda-bld/noarch
         ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
mkdir -p "$CONDA_PREFIX"/conda-bld/noarch


In tests/test_installer.sh line 20:
mv anaconda-ident-config-999-default_0.tar.bz2 $CONDA_PREFIX/conda-bld/noarch
                                               ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
mv anaconda-ident-config-999-default_0.tar.bz2 "$CONDA_PREFIX"/conda-bld/noarch


In tests/test_installer.sh line 21:
python -m conda_index $CONDA_PREFIX/conda-bld
                      ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
python -m conda_index "$CONDA_PREFIX"/conda-bld


In tests/test_installer.sh line 37:
if [ ${vflag:2:2} -gt 22 ]; then
     ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
if [ "${vflag:2:2}" -gt 22 ]; then


In tests/test_installer.sh line 60:
if [ -f AIDTest*.sh ]; then
        ^---------^ SC2144 (error): -f doesn't work with globs. Use a for loop.


In tests/test_installer.sh line 62:
elif [ -f AIDTest*.exe ]; then
          ^----------^ SC2144 (error): -f doesn't work with globs. Use a for loop.


In tests/test_installer.sh line 66:
  exit -1
       ^-- SC2242 (error): Can only exit with status 0-255. Other data should be written to stdout/stderr.


In tests/test_keymgr.sh line 5:
SCRIPTDIR=$(cd $(dirname $BASH_SOURCE[0]) && pwd)
               ^------------------------^ SC2046 (warning): Quote this to prevent word splitting.
                         ^-- SC1087 (error): Use braces when expanding arrays, e.g. ${array[idx]} (or ${var}[.. to quiet).
                         ^----------^ SC2128 (warning): Expanding an array without an index only gives the first element.
                         ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
SCRIPTDIR=$(cd $(dirname "$BASH_SOURCE"[0]) && pwd)


In tests/test_keymgr.sh line 6:
source $CONDA_PREFIX/etc/profile.d/conda.sh
       ^-- SC1091 (info): Not following: ./etc/profile.d/conda.sh was not specified as input (see shellcheck -x).
       ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
source "$CONDA_PREFIX"/etc/profile.d/conda.sh


In tests/test_keymgr.sh line 10:
grep '|' $SCRIPTDIR/config_tests.txt | while IFS="|" read cstr def cha rtk bstr; do
         ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                     ^--^ SC2162 (info): read without -r will mangle backslashes.

Did you mean: 
grep '|' "$SCRIPTDIR"/config_tests.txt | while IFS="|" read cstr def cha rtk bstr; do


In tests/test_keymgr.sh line 26:
    [ -f "$fname" ] || exit -1
                            ^-- SC2242 (error): Can only exit with status 0-255. Other data should be written to stdout/stderr.


In tests/test_keymgr.sh line 27:
    rm -rf $CONDA_PREFIX/pkgs/${fname%%.*}
           ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                              ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    rm -rf "$CONDA_PREFIX"/pkgs/"${fname%%.*}"


In tests/test_keymgr.sh line 28:
    conda install -p $CONDA_PREFIX $fname --freeze-installed --offline --yes
                     ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                   ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    conda install -p "$CONDA_PREFIX" "$fname" --freeze-installed --offline --yes


In tests/test_keymgr.sh line 30:
    conda list testpkg | grep -q ^testpkg || exit -1
                                                  ^-- SC2242 (error): Can only exit with status 0-255. Other data should be written to stdout/stderr.


In tests/test_keymgr.sh line 33:
        ANACONDA_IDENT_DEBUG=1 SKIP_INSTALL=1 python $SCRIPTDIR/test_config.py
                                                     ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
        ANACONDA_IDENT_DEBUG=1 SKIP_INSTALL=1 python "$SCRIPTDIR"/test_config.py


In tests/test_keymgr.sh line 34:
    conda remove -p $CONDA_PREFIX testpkg --force --offline --yes
                    ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    conda remove -p "$CONDA_PREFIX" testpkg --force --offline --yes


In tests/test_keymgr.sh line 35:
    rm $fname
       ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    rm "$fname"

For more information:
  https://www.shellcheck.net/wiki/SC1087 -- Use braces when expanding arrays,...
  https://www.shellcheck.net/wiki/SC2144 -- -f doesn't work with globs. Use a...
  https://www.shellcheck.net/wiki/SC2148 -- Tips depend on target shell and y...
```