### PR TITLE
use condarc.d instead of etc

### DIFF
--- a/anaconda_ident/install.py
+++ b/anaconda_ident/install.py
@@ -578,7 +578,7 @@ def main():
         if verbose:
             print(line)
         return 0
-    fname = join(sys.prefix, "etc", "anaconda_ident.yml")
+    fname = join(sys.prefix, "condarc.d", "anaconda_ident.yml")
     condarc = read_condarc(args, fname)
     if not success:
         if verbose:

--- a/anaconda_ident/patch.py
+++ b/anaconda_ident/patch.py
@@ -126,7 +126,8 @@ def _aid_user_agent(ctx):
 
 
 # conda.base.context.SEARCH_PATH
-# Add anaconda_ident's condarc location
+# Add anaconda_ident's old condarc location for back compatibility
+# We will deprecate this as we migrate existing customers
 if not hasattr(c_context, "_OLD_SEARCH_PATH"):
     _debug("Adding anaconda_ident.yml to the search path")
     sp = c_context._OLD_SEARCH_PATH = c_context.SEARCH_PATH


### PR DESCRIPTION
I must sheepishly admit I did not appreciate that `$CONDA_ROOT/condarc.d` would be a great standard place to put `anaconda_ident.yml`. This enables us to deprecate the need to patch the search path

To support migration:
- For now, the search path patch remains, so customers with older anaconda-ident-config files will still work with upgrades
- anaconda-keymgr has a `--compatibility` flag. If set, it will put the file in both places, making it compatible with any version of anaconda-ident. If not set, it will only put it in the new place, and the `anaconda-ident` depenendency will have a lower bound to ensure the user upgrades. 